### PR TITLE
Mask in spark submit

### DIFF
--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -1651,7 +1651,7 @@ class SparkContext(config: SparkConf) extends Logging {
 
     val timestamp = if (addedOnSubmit) startTime else System.currentTimeMillis
     if (!isArchive && addedFiles.putIfAbsent(key, timestamp).isEmpty) {
-      logInfo(s"Added file $path at $key with timestamp $timestamp")
+      logInfo(s"Added file ${Utils.maskUserInfo(path)} at ${Utils.maskUserInfo(key)} with timestamp $timestamp")
       // Fetch the file locally so that closures which are run on the driver can still use the
       // SparkFiles API to access files.
       Utils.fetchFile(uri.toString, new File(SparkFiles.getRootDirectory()), conf,
@@ -1662,7 +1662,7 @@ class SparkContext(config: SparkConf) extends Logging {
         addedArchives.putIfAbsent(
           UriBuilder.fromUri(new URI(key)).fragment(uri.getFragment).build().toString,
           timestamp).isEmpty) {
-      logInfo(s"Added archive $path at $key with timestamp $timestamp")
+      logInfo(s"Added archive ${Utils.maskUserInfo(path)} at ${Utils.maskUserInfo(key)} with timestamp $timestamp")
       // If the scheme is file, use URI to simply copy instead of downloading.
       val uriToUse = if (!isLocal && scheme == "file") uri else new URI(key)
       val uriToDownload = UriBuilder.fromUri(uriToUse).fragment(null).build()
@@ -1672,7 +1672,7 @@ class SparkContext(config: SparkConf) extends Logging {
         SparkFiles.getRootDirectory(),
         if (uri.getFragment != null) uri.getFragment else source.getName)
       logInfo(
-        s"Unpacking an archive $path from ${source.getAbsolutePath} to ${dest.getAbsolutePath}")
+        s"Unpacking an archive ${Utils.maskUserInfo(path)} from ${Utils.maskUserInfo({source.getAbsolutePath})} to ${dest.getAbsolutePath}")
       Utils.deleteRecursively(dest)
       Utils.unpack(source, dest)
       postEnvironmentUpdate()
@@ -2028,13 +2028,12 @@ class SparkContext(config: SparkConf) extends Logging {
         val (added, existed) = keys.partition(addedJars.putIfAbsent(_, timestamp).isEmpty)
         if (added.nonEmpty) {
           val jarMessage = if (scheme != "ivy") "JAR" else "dependency jars of Ivy URI"
-          logInfo(s"Added $jarMessage $path at ${added.mkString(",")} with timestamp $timestamp")
+          logInfo(s"Added $jarMessage ${Utils.maskUserInfo(path)} at ${Utils.maskUserInfo({added.mkString(",")})} with timestamp $timestamp")
           postEnvironmentUpdate()
         }
         if (existed.nonEmpty) {
           val jarMessage = if (scheme != "ivy") "JAR" else "dependency jars of Ivy URI"
-          logInfo(s"The $jarMessage $path at ${existed.mkString(",")} has been added already." +
-            " Overwriting of added jar is not supported in the current version.")
+          logInfo(s"The $jarMessage ${Utils.maskUserInfo(path)} at ${Utils.maskUserInfo({added.mkString(",")})} has been added already." + " Overwriting of added jar is not supported in the current version.")
         }
       }
     }

--- a/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/SparkSubmit.scala
@@ -422,7 +422,7 @@ private[spark] class SparkSubmit extends Logging {
                 ".",
                 if (resolvedUri.getFragment != null) resolvedUri.getFragment else source.getName)
               logInfo(
-                s"Unpacking an archive $resolvedUri " +
+                s"Unpacking an archive ${Utils.maskUserInfo(resolvedUri.toString())} " +
                   s"from ${source.getAbsolutePath} to ${dest.getAbsolutePath}")
               Utils.deleteRecursively(dest)
               Utils.unpack(source, dest)
@@ -1377,7 +1377,7 @@ private[spark] object SparkSubmitUtils extends Logging {
         brr.setName(s"repo-${i + 1}")
         cr.add(brr)
         // scalastyle:off println
-        printStream.println(s"$repo added as a remote repository with the name: ${brr.getName}")
+        printStream.println(s"${Utils.maskUserInfo(repo)} added as a remote repository with the name: ${brr.getName}")
         // scalastyle:on println
       }
 

--- a/core/src/main/scala/org/apache/spark/executor/Executor.scala
+++ b/core/src/main/scala/org/apache/spark/executor/Executor.scala
@@ -978,14 +978,14 @@ private[spark] class Executor(
     synchronized {
       // Fetch missing dependencies
       for ((name, timestamp) <- newFiles if currentFiles.getOrElse(name, -1L) < timestamp) {
-        logInfo(s"Fetching $name with timestamp $timestamp")
+        logInfo(s"Fetching ${Utils.maskUserInfo(name)} with timestamp $timestamp")
         // Fetch file with useCache mode, close cache for local mode.
         Utils.fetchFile(name, new File(SparkFiles.getRootDirectory()), conf,
           hadoopConf, timestamp, useCache = !isLocal)
         currentFiles(name) = timestamp
       }
       for ((name, timestamp) <- newArchives if currentArchives.getOrElse(name, -1L) < timestamp) {
-        logInfo(s"Fetching $name with timestamp $timestamp")
+        logInfo(s"Fetching ${Utils.maskUserInfo(name)} with timestamp $timestamp")
         val sourceURI = new URI(name)
         val uriToDownload = UriBuilder.fromUri(sourceURI).fragment(null).build()
         val source = Utils.fetchFile(uriToDownload.toString, Utils.createTempDir(), conf,
@@ -994,7 +994,7 @@ private[spark] class Executor(
           SparkFiles.getRootDirectory(),
           if (sourceURI.getFragment != null) sourceURI.getFragment else source.getName)
         logInfo(
-          s"Unpacking an archive $name from ${source.getAbsolutePath} to ${dest.getAbsolutePath}")
+          s"Unpacking an archive ${Utils.maskUserInfo(name)} from ${Utils.maskUserInfo({source.getAbsolutePath})} to ${dest.getAbsolutePath}")
         Utils.deleteRecursively(dest)
         Utils.unpack(source, dest)
         currentArchives(name) = timestamp
@@ -1005,7 +1005,7 @@ private[spark] class Executor(
           .orElse(currentJars.get(localName))
           .getOrElse(-1L)
         if (currentTimeStamp < timestamp) {
-          logInfo(s"Fetching $name with timestamp $timestamp")
+          logInfo(s"Fetching ${Utils.maskUserInfo(name)} with timestamp $timestamp")
           // Fetch file with useCache mode, close cache for local mode.
           Utils.fetchFile(name, new File(SparkFiles.getRootDirectory()), conf,
             hadoopConf, timestamp, useCache = !isLocal)
@@ -1013,7 +1013,7 @@ private[spark] class Executor(
           // Add it to our class loader
           val url = new File(SparkFiles.getRootDirectory(), localName).toURI.toURL
           if (!urlClassLoader.getURLs().contains(url)) {
-            logInfo(s"Adding $url to class loader")
+            logInfo(s"Adding ${Utils.maskUserInfo(url.toString())} to class loader")
             urlClassLoader.addURL(url)
           }
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?
The changes are proposed to have HTTPS URLs with credentials embedded in them for different options supplied with spark-submit command.


### Why are the changes needed?
These changes are done to enable HTTPS URLs with credentials and for masking the log statements showing credentials within the URLs. Also, to mask the credentials which are shown with the URLs in Spark logs.


### Does this PR introduce _any_ user-facing change?
No..
-->


### How was this patch tested?
These patches are tested in local environment and the customer setup successfully..
-->
